### PR TITLE
ci(athena-parent): 更新 GitHub Actions 权限和Checkout配置- 添加 permissions 配置…

### DIFF
--- a/.github/workflows/cd-master.yml
+++ b/.github/workflows/cd-master.yml
@@ -15,6 +15,12 @@ on:
           - minor
           - major
 
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -23,7 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Set up JDK 21


### PR DESCRIPTION
…，授予必要的写权限

- 修改 checkout步骤，使用 PAT_TOKEN 或 GITHUB_TOKEN
- 保持 fetch-depth: 0 设置，以获取完整历史记录